### PR TITLE
Multipart form data

### DIFF
--- a/Example/Swifty/HTTPBinWebService.swift
+++ b/Example/Swifty/HTTPBinWebService.swift
@@ -27,4 +27,10 @@ class HTTPBin: WebService {
                      .canHaveConstraints(true)
     }
     
+    static func uploadImageRequest(with parameters: [String: Any], multipartData:[MultipartData]) -> NetworkResource {
+        return server.post("post")
+            .multipart(parameters, multipartData: multipartData)
+            .canHaveConstraints(true)
+    }
+    
 }

--- a/Example/Swifty/ViewController.swift
+++ b/Example/Swifty/ViewController.swift
@@ -29,6 +29,18 @@ class ViewController: UIViewController {
             }
             
         }
+        uploadImage()
+    }
+    
+    func uploadImage() {
+        let parameters = ["comment":"hello"]
+        let imageData = UIImagePNGRepresentation(UIImage(named:"SwiftyLogo")!)
+        let multipartData = MultipartData(data: imageData!, parameterName: "image")
+        HTTPBin.uploadImageRequest(with: parameters, multipartData: [multipartData]).load(successBlock: { (data) in
+            print("Image uploaded successfully")
+        }) { (error) in
+            print("Multipart error : \(error.debugDescription)")
+        }
     }
     
 }

--- a/Swifty/Classes/Core/MultipartData.swift
+++ b/Swifty/Classes/Core/MultipartData.swift
@@ -1,0 +1,47 @@
+//
+//  MultipartData.swift
+//
+//  Created by Sunil Sharma on 15/10/17.
+//
+
+import Foundation
+
+public struct MultipartData {
+    private let data: Data
+    private let parameterName: String
+    private let filename: String?
+    private let mimeType: String
+    
+    public init(data: Data, parameterName:String, filename:String? = nil, mimeType:String? = nil) {
+        self.data = data
+        self.parameterName = parameterName
+        self.filename = filename
+        if let mimeType = mimeType {
+            self.mimeType = mimeType
+        } else {
+            self.mimeType = data.MIMEType()
+        }
+    }
+    
+    internal func getFormData(boundary:String) -> Data {
+        var body = ""
+        body += "--\(boundary)\r\n"
+        body += "Content-Disposition: form-data; "
+        body += "name=\"\(parameterName)\""
+        if let filename = filename {
+            body += "; filename=\"\(filename)\""
+        }
+        body += "\r\n"
+        body += "Content-Type: \(mimeType)\r\n\r\n"
+        
+        var bodyData = Data()
+        if let data = body.data(using: .utf8) {
+            bodyData.append(data)
+        } else {
+            assertionFailure("Unable to encode fields name \(parameterName) \(filename == nil ? "" : "and") \(filename ?? "") to data using .utf8 encoding.")
+        }
+        bodyData.append(data)
+        bodyData.append("\r\n".data(using: .utf8)!)
+        return bodyData
+    }
+}

--- a/Swifty/Classes/WebService/NetworkResource+Modifiers.swift
+++ b/Swifty/Classes/WebService/NetworkResource+Modifiers.swift
@@ -244,5 +244,38 @@ public extension NetworkResource {
         
         return components.map { "\($0)=\($1)" }.joined(separator: "&")
     }
+    
+    /// Returns encoded multipart form-data with given parameters.
+    ///
+    /// - Parameters:
+    ///   - parameters: parameters
+    ///   - multipartDatas: array of `MultipartData`
+    ///   - boundary: boundary to create multipart form-data
+    /// - Returns: Data
+    internal func getMultipartFormData(_ parameters: [String: Any]?, multipartDatas:[MultipartData], boundary:String) -> Data? {
+        var bodyData = Data()
+        // Parameters
+        if let parameters = parameters {
+            for (key, value) in parameters {
+                let valueObj: Any = value is NSNull ? "null" : value
+                var body = ""
+                body += "--\(boundary)\r\n"
+                body += "Content-Disposition: form-data; name=\"\(key)\""
+                body += "\r\n\r\n\(valueObj)\r\n"
+                if let data = body.data(using: .utf8) {
+                    bodyData.append(data)
+                } else {
+                    return nil
+                }
+            }
+        }
+        
+        // multiipart data
+        for part in multipartDatas {
+            bodyData.append(part.getFormData(boundary: boundary))
+        }
+        bodyData.append("--\(boundary)--\r\n".data(using: .utf8)!)
+        return bodyData
+    }
 }
 

--- a/Swifty/Classes/WebService/NetworkResourceWithBody.swift
+++ b/Swifty/Classes/WebService/NetworkResourceWithBody.swift
@@ -160,7 +160,7 @@ public extension NetworkResourceWithBody {
         guard self.creationError == nil else {
             return self
         }
-        let boundary = String(format: "com.swifty.multipart.%08x%08x", arc4random(), arc4random())
+        let boundary = String(format: "com.swifty.multipart-data.%08x%08x", arc4random(), arc4random())
         /// Sets the content-type
         self.contentType("multipart/form-data; boundary=\(boundary)")
         

--- a/Swifty/Classes/WebService/NetworkResourceWithBody.swift
+++ b/Swifty/Classes/WebService/NetworkResourceWithBody.swift
@@ -146,6 +146,36 @@ public extension NetworkResourceWithBody {
         return self
     }
     
+    /// Sets the HTTP Body of the resource with multipart form-data
+    ///
+    /// Internally sets the Content-Type header of the resource to "multipart/form-data"
+    ///
+    /// - Parameters:
+    ///   - parameters: parameters
+    ///   - multipartDatas: array of `MultipartData`
+    /// - Returns: NetworkResourceWithBody
+    @discardableResult func multipart(_ parameters: Dictionary<String, Any>?, multipartData:[MultipartData]) -> NetworkResourceWithBody {
+        
+        /// Checking for creation error
+        guard self.creationError == nil else {
+            return self
+        }
+        let boundary = String(format: "com.swifty.multipart.%08x%08x", arc4random(), arc4random())
+        /// Sets the content-type
+        self.contentType("multipart/form-data; boundary=\(boundary)")
+        
+        let multipartFormData = getMultipartFormData(parameters, multipartDatas: multipartData, boundary: boundary)
+        
+        ///Sets the http body
+        if let bodyData = multipartFormData {
+            self.request.httpBody = bodyData
+        } else {
+            self.creationError = WebServiceError.fieldsEncodingFailure(dictionary: parameters ?? [:])
+        }
+        
+        return self
+    }
+    
     /// Sets the HTTP Body of the resource to the given Data
     ///
     /// - Parameters:

--- a/Swifty/Classes/WebService/Utility.swift
+++ b/Swifty/Classes/WebService/Utility.swift
@@ -14,3 +14,32 @@ import Foundation
 extension NSNumber {
     internal var isBool: Bool { return CFBooleanGetTypeID() == CFGetTypeID(self) }
 }
+
+extension Data {
+    
+    func MIMEType() -> String {
+        var value = [UInt8](repeating:0, count:1)
+        self.copyBytes(to: &value, count: 1)
+        var mimeType = "application/octet-stream"
+        switch (value[0]){
+        case 0xFF:
+            mimeType = "image/jpeg";
+        case 0x89:
+            mimeType = "image/png";
+        case 0x47:
+            mimeType = "image/gif";
+        case 0x49, 0x4D:
+            mimeType = "image/tiff";
+        case 0x25:
+            mimeType = "application/pdf";
+        case 0xD0:
+            mimeType = "application/vnd";
+        case 0x46:
+            mimeType = "text/plain";
+        default:
+            mimeType = "application/octet-stream";
+        }
+        return mimeType
+    }
+}
+


### PR DESCRIPTION
Implementation of Multipart form-data modifier.

During implementation I have created `Data` extension to get MIME Type. This extension can be used in method `func data(_ data: Data, mimeType: String?) -> NetworkResourceWithBody`, once this pull request is accepted then I will update this method.