### PR TITLE
Support for Codable (Encodable + Decodable)

### DIFF
--- a/Sources/Core/Error.swift
+++ b/Sources/Core/Error.swift
@@ -38,6 +38,8 @@ public enum WebServiceErrorCodes: Int {
     case invalidQueryStringWithURL
     /// Errors while encoding the given JSON.
     case jsonEncodingFailure
+    /// Errors while encoding the given type that conforms to the Codable Protocol.
+    case codableEncodingFailure
 }
 
 /// Errors that can occur in the WebService domain
@@ -80,9 +82,14 @@ public class WebServiceError {
         return NSError(domain: WebServiceError.errorDomain, code: WebServiceErrorCodes.jsonEncodingFailure.rawValue, userInfo: self.userInfo(description: "Unable to serialize JSON: \(dictionary), due to error: \(String(describing: error?.localizedDescription))"))
     }
     
-    /// JSON Encoding failure.
+    /// JSON Array Encoding failure.
     public static func jsonEncodingFailure(array: [Any], error: Error?) -> NSError {
         return NSError(domain: WebServiceError.errorDomain, code: WebServiceErrorCodes.jsonEncodingFailure.rawValue, userInfo: self.userInfo(description: "Unable to serialize JSON Array: \(array), due to error: \(String(describing: error?.localizedDescription))"))
+    }
+    
+    /// Codable Encoding failure.
+    public static func codableEncodingFailure(error: Error?) -> NSError {
+        return NSError(domain: WebServiceError.errorDomain, code: WebServiceErrorCodes.codableEncodingFailure.rawValue, userInfo: self.userInfo(description: "Unable to JSON Serialize the given Codable type due to error: \(String(describing: error?.localizedDescription))"))
     }
     
     /* User Info Helper */

--- a/Sources/WebService/NetworkResource+Loaders.swift
+++ b/Sources/WebService/NetworkResource+Loaders.swift
@@ -34,7 +34,7 @@ extension NetworkResource {
         })
     }
     
-    /// Loads the network resource, and calls the success block with unserialized Data and HTTPURLResponse or the failure block with the error
+    /// Loads the network resource, and calls the success block with unserialized Data or the failure block with the error
     ///
     /// - Parameters:
     ///   - successBlock: block to be executed when response doesn't have any errors.

--- a/Sources/WebService/NetworkResource.swift
+++ b/Sources/WebService/NetworkResource.swift
@@ -39,8 +39,12 @@ public class NetworkResource: NSObject {
     /// Can have constraints.
     var canHaveConstraints = false
     
-    /// Creation error
-    var creationError: NSError?
+    /// Error (if any) encountered while Webservice was creating this request.
+    ///
+    /// Set this error in your own extensions of `NetworkResource` or `NetworkResourceWithBody` Modifiers to inform callers of errors that fail the request, for example, JSON encoding failures.
+    ///
+    /// If this not `nil` at the time the `load` method on this request is called, the request will **automatically fail** with this error without ever hitting the network.
+    public var creationError: NSError?
     
 // MARK: - Initializers
     

--- a/Sources/WebService/NetworkResourceWithBody.swift
+++ b/Sources/WebService/NetworkResourceWithBody.swift
@@ -158,6 +158,34 @@ public extension NetworkResourceWithBody {
         return self
     }
     
+    /// Sets the HTTP Body as JSON encoded from a type conforming to the `Encodable (Codable)` protocol
+    ///
+    /// Internally sets the Content-Type header of the resource to "application/json"
+    ///
+    /// - Parameters:
+    ///   - body: A type conforming to the `Encodable` Protocol
+    ///   - options: The `JSONEncoder` instance to use. Defaults to `JSONEncoder()`
+    /// - Returns: NetworkResourceWithBody
+    @discardableResult func json<T>(body: T, encoder: JSONEncoder = JSONEncoder()) -> NetworkResourceWithBody where T: Encodable {
+        
+        ///Checking for creation error
+        guard self.creationError == nil else {
+            return self
+        }
+        ///Sets the content type
+        self.contentType("application/json")
+        
+        ///Sets the HTTP Body
+        do {
+            self.request.httpBody = try encoder.encode(body)
+        }
+        catch let error {
+            self.creationError = WebServiceError.codableEncodingFailure(error: error)
+        }
+        
+        return self
+    }
+    
     /// Sets the HTTP Body as JSON Array
     ///
     /// Internally sets the Content-Type header of the resource to "application/json"

--- a/Sources/WebService/NetworkResourceWithBody.swift
+++ b/Sources/WebService/NetworkResourceWithBody.swift
@@ -166,7 +166,7 @@ public extension NetworkResourceWithBody {
     ///   - body: A type conforming to the `Encodable` Protocol
     ///   - options: The `JSONEncoder` instance to use. Defaults to `JSONEncoder()`
     /// - Returns: NetworkResourceWithBody
-    @discardableResult func json<T>(body: T, encoder: JSONEncoder = JSONEncoder()) -> NetworkResourceWithBody where T: Encodable {
+    @discardableResult func json<T>(encodable: T, encoder: JSONEncoder = JSONEncoder()) -> NetworkResourceWithBody where T: Encodable {
         
         ///Checking for creation error
         guard self.creationError == nil else {
@@ -177,7 +177,7 @@ public extension NetworkResourceWithBody {
         
         ///Sets the HTTP Body
         do {
-            self.request.httpBody = try encoder.encode(body)
+            self.request.httpBody = try encoder.encode(encodable)
         }
         catch let error {
             self.creationError = WebServiceError.codableEncodingFailure(error: error)

--- a/Sources/WebService/NetworkResourceWithBody.swift
+++ b/Sources/WebService/NetworkResourceWithBody.swift
@@ -166,7 +166,7 @@ public extension NetworkResourceWithBody {
     ///   - body: A type conforming to the `Encodable` Protocol
     ///   - options: The `JSONEncoder` instance to use. Defaults to `JSONEncoder()`
     /// - Returns: NetworkResourceWithBody
-    @discardableResult func json<T>(encodable: T, encoder: JSONEncoder = JSONEncoder()) -> NetworkResourceWithBody where T: Encodable {
+    @discardableResult func json<T: Encodable>(encodable: T, encoder: JSONEncoder = JSONEncoder()) -> NetworkResourceWithBody {
         
         ///Checking for creation error
         guard self.creationError == nil else {

--- a/Tests/SwiftyTests/WebServiceTests.swift
+++ b/Tests/SwiftyTests/WebServiceTests.swift
@@ -221,15 +221,19 @@ class WebServiceTests: XCTestCase {
         let person = Person(name: "Programmer", age: 10, languages: ["ObjC", "Swift"])
         let resource = TestWebService.codableRequest(body: person)
         
-        resource.loadJSON(Person.self, successBlock: { (decodedPerson) in
-            XCTAssertNotNil(decodedPerson)
-            XCTAssertEqual(decodedPerson.name, person.name)
-            XCTAssertEqual(decodedPerson.age, person.age)
-            XCTAssertEqual(decodedPerson.languages, person.languages)
+        let expectation = self.expectation(description: "Should be able to decode the Person object in the response")
+        
+        resource.loadJSON(HTTPBinPostResponse.self, successBlock: { (response) in
+            XCTAssertNotNil(response.person)
+            XCTAssertEqual(response.person.name, person.name)
+            XCTAssertEqual(response.person.age, person.age)
+            XCTAssertEqual(response.person.languages, person.languages)
+            expectation.fulfill()
         }) { (error) in
-            
+            XCTFail("Couldn't decode the Person object in the response")
         }
         
+        self.waitForExpectations(timeout: 10, handler: nil)
     }
     
     func testJSONParser() {
@@ -241,7 +245,7 @@ class WebServiceTests: XCTestCase {
                 expectation.fulfill()
             }
         }) { (error) in
-            XCTFail()
+            XCTFail("JSON Parsing Failure / Didn't the JSON that was expected: \(error.localizedDescription)")
         }
         
         self.waitForExpectations(timeout: 4, handler: nil)
@@ -284,4 +288,12 @@ struct Person: Codable {
     let name: String
     let age: Int
     let languages: [String]
+}
+
+struct HTTPBinPostResponse: Codable {
+    let person: Person
+    
+    enum CodingKeys: String, CodingKey {
+        case person = "json"
+    }
 }

--- a/Tests/SwiftyTests/WebServiceTests.swift
+++ b/Tests/SwiftyTests/WebServiceTests.swift
@@ -236,6 +236,22 @@ class WebServiceTests: XCTestCase {
         self.waitForExpectations(timeout: 10, handler: nil)
     }
     
+    func testJSONDecodingforCodableError() {
+        
+        let person = Person(name: "Programmer", age: 10, languages: ["ObjC", "Swift"])
+        let resource = TestWebService.codableRequest(body: person)
+        
+        let expectation = self.expectation(description: "Should fail to decode the response into Person directly due to nesting")
+        
+        resource.loadJSON(Person.self, successBlock: { (response) in
+            XCTFail()
+        }) { (error) in
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 10, handler: nil)
+    }
+    
     func testJSONParser() {
         
         let expectation = self.expectation(description: "Got the IP in response")
@@ -245,7 +261,7 @@ class WebServiceTests: XCTestCase {
                 expectation.fulfill()
             }
         }) { (error) in
-            XCTFail("JSON Parsing Failure / Didn't the JSON that was expected: \(error.localizedDescription)")
+            XCTFail("JSON Parsing Failure / Didn't get the JSON that was expected: \(error.localizedDescription)")
         }
         
         self.waitForExpectations(timeout: 4, handler: nil)

--- a/Tests/SwiftyTests/WebServiceTests.swift
+++ b/Tests/SwiftyTests/WebServiceTests.swift
@@ -194,6 +194,24 @@ class WebServiceTests: XCTestCase {
         XCTAssertEqual(resource.request.url?.absoluteString, "https://httpbin.org/path?\(query)")
     }
     
+    func testJSONEncodingforCodable() {
+        
+        let person = Person(name: "Programmer", age: 10, languages: ["ObjC", "Swift"])
+        let resource = TestWebService.postRequest().json(body: person)
+        
+        XCTAssertNotNil(resource.request.httpBody)
+        XCTAssertEqual(resource.request.allHTTPHeaderFields!["Content-Type"], "application/json")
+        
+        let decoder = JSONDecoder()
+        let decodedPerson = try? decoder.decode(Person.self, from: resource.request.httpBody!)
+        
+        XCTAssertNotNil(resource)
+        XCTAssertNotNil(decodedPerson)
+        XCTAssertEqual(decodedPerson?.name, person.name)
+        XCTAssertEqual(decodedPerson?.age, person.age)
+        XCTAssertEqual(decodedPerson!.languages, person.languages)
+    }
+    
     func testJSONParser() {
         
         let expectation = self.expectation(description: "Got the IP in response")
@@ -203,7 +221,7 @@ class WebServiceTests: XCTestCase {
                 expectation.fulfill()
             }
         }) { (error) in
-            
+            XCTFail()
         }
         
         self.waitForExpectations(timeout: 4, handler: nil)
@@ -242,3 +260,8 @@ class WebServiceTests: XCTestCase {
     
 }
 
+struct Person: Codable {
+    let name: String
+    let age: Int
+    let languages: [String]
+}

--- a/Tests/SwiftyTests/WebServiceTests.swift
+++ b/Tests/SwiftyTests/WebServiceTests.swift
@@ -216,6 +216,22 @@ class WebServiceTests: XCTestCase {
         XCTAssertEqual(decodedPerson!.languages, person.languages)
     }
     
+    func testJSONDecodingforCodable() {
+        
+        let person = Person(name: "Programmer", age: 10, languages: ["ObjC", "Swift"])
+        let resource = TestWebService.codableRequest(body: person)
+        
+        resource.loadJSON(Person.self, successBlock: { (decodedPerson) in
+            XCTAssertNotNil(decodedPerson)
+            XCTAssertEqual(decodedPerson.name, person.name)
+            XCTAssertEqual(decodedPerson.age, person.age)
+            XCTAssertEqual(decodedPerson.languages, person.languages)
+        }) { (error) in
+            
+        }
+        
+    }
+    
     func testJSONParser() {
         
         let expectation = self.expectation(description: "Got the IP in response")

--- a/Tests/SwiftyTests/WebServiceTests.swift
+++ b/Tests/SwiftyTests/WebServiceTests.swift
@@ -34,7 +34,7 @@ class TestWebService: WebService {
         return server.post("post")
     }
     
-    static func codableRequest<T>(body: T) -> NetworkResourceWithBody where T: Encodable {
+    static func codableRequest<T: Encodable>(body: T) -> NetworkResource {
         return server.post("post").json(encodable: body)
     }
     

--- a/Tests/SwiftyTests/WebServiceTests.swift
+++ b/Tests/SwiftyTests/WebServiceTests.swift
@@ -34,6 +34,10 @@ class TestWebService: WebService {
         return server.post("post")
     }
     
+    static func codableRequest<T>(body: T) -> NetworkResourceWithBody where T: Encodable {
+        return server.post("post").json(encodable: body)
+    }
+    
     static func getIP() -> NetworkResource {
         return server.get("ip")
     }
@@ -197,15 +201,15 @@ class WebServiceTests: XCTestCase {
     func testJSONEncodingforCodable() {
         
         let person = Person(name: "Programmer", age: 10, languages: ["ObjC", "Swift"])
-        let resource = TestWebService.postRequest().json(body: person)
+        let resource = TestWebService.codableRequest(body: person)
         
+        XCTAssertNotNil(resource)
         XCTAssertNotNil(resource.request.httpBody)
         XCTAssertEqual(resource.request.allHTTPHeaderFields!["Content-Type"], "application/json")
         
         let decoder = JSONDecoder()
         let decodedPerson = try? decoder.decode(Person.self, from: resource.request.httpBody!)
         
-        XCTAssertNotNil(resource)
         XCTAssertNotNil(decodedPerson)
         XCTAssertEqual(decodedPerson?.name, person.name)
         XCTAssertEqual(decodedPerson?.age, person.age)


### PR DESCRIPTION
- Adds a new `.json(encodable: encoder:)` modifier to attach `Encodable` objects into request bodies
- Adds a new method `.loadJSON<T: Decodable>(decodable: decoder:)` to support loading `Decodable`objects from network responses directly.
- Added a new `codableEncodingFailure` error in `WebserviceErrors`
- The `creationError` property in `NetworkResource` is now public, so that it can be utilized by a user's custom extensions.
- Added Tests for `Codable` encoding & decoding.
- Fix some documentation & tests.