### PR TITLE
Added Support for Response Mocking with .mock()

### DIFF
--- a/Example/Swifty.xcodeproj/project.pbxproj
+++ b/Example/Swifty.xcodeproj/project.pbxproj
@@ -557,7 +557,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = com.flipkart.swifty;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -573,7 +573,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = com.flipkart.swifty;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -591,7 +591,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Swifty_Example.app/Swifty_Example";
 			};
 			name = Debug;
@@ -606,7 +606,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Swifty_Example.app/Swifty_Example";
 			};
 			name = Release;

--- a/Example/Swifty.xcodeproj/project.pbxproj
+++ b/Example/Swifty.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		167F7FAB1FE10E51002437B4 /* MockingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167F7FAA1FE10E51002437B4 /* MockingTests.swift */; };
+		167F7FAE1FE111C1002437B4 /* mockedResponse.json in Resources */ = {isa = PBXBuildFile; fileRef = 167F7FAC1FE10F1E002437B4 /* mockedResponse.json */; };
 		16C7039B1F64318200BF4E30 /* HTTPBinWebService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C7039A1F64318200BF4E30 /* HTTPBinWebService.swift */; };
 		16C7039D1F643CC000BF4E30 /* IPConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C7039C1F643CC000BF4E30 /* IPConstraint.swift */; };
 		16C703A11F643CF600BF4E30 /* IPHeaderInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C703A01F643CF600BF4E30 /* IPHeaderInterceptor.swift */; };
@@ -32,6 +34,8 @@
 
 /* Begin PBXFileReference section */
 		143C1840FC49E5F98E38BEC1 /* Pods_Swifty_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Swifty_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		167F7FAA1FE10E51002437B4 /* MockingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockingTests.swift; sourceTree = "<group>"; };
+		167F7FAC1FE10F1E002437B4 /* mockedResponse.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = mockedResponse.json; sourceTree = "<group>"; };
 		16C7039A1F64318200BF4E30 /* HTTPBinWebService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPBinWebService.swift; sourceTree = "<group>"; };
 		16C7039C1F643CC000BF4E30 /* IPConstraint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IPConstraint.swift; sourceTree = "<group>"; };
 		16C703A01F643CF600BF4E30 /* IPHeaderInterceptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IPHeaderInterceptor.swift; sourceTree = "<group>"; };
@@ -142,6 +146,7 @@
 			isa = PBXGroup;
 			children = (
 				607FACEB1AFB9204008FA782 /* PerformanceTests.swift */,
+				167F7FAA1FE10E51002437B4 /* MockingTests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 			);
 			path = Tests;
@@ -151,6 +156,7 @@
 			isa = PBXGroup;
 			children = (
 				607FACEA1AFB9204008FA782 /* Info.plist */,
+				167F7FAC1FE10F1E002437B4 /* mockedResponse.json */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -268,6 +274,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */,
+				167F7FAE1FE111C1002437B4 /* mockedResponse.json in Resources */,
 				607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */,
 				607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */,
 			);
@@ -404,6 +411,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				167F7FAB1FE10E51002437B4 /* MockingTests.swift in Sources */,
 				607FACEC1AFB9204008FA782 /* PerformanceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Tests/MockingTests.swift
+++ b/Example/Tests/MockingTests.swift
@@ -27,7 +27,7 @@ class MockingTests: XCTestCase {
         
         let expectation = self.expectation(description: "Should get mocked response from the file")
         
-        TestWebService.getIP().mock(filename: "mockedResponse").loadJSON(successBlock: { (response) in
+        TestWebService.getIP().mock(withFile: "mockedResponse").loadJSON(successBlock: { (response) in
             XCTAssertNotNil(response)
             XCTAssert(response is [String: Any])
             if let json = response as? [String: Any], let message = json["message"] as? String {

--- a/Example/Tests/MockingTests.swift
+++ b/Example/Tests/MockingTests.swift
@@ -1,0 +1,47 @@
+//
+//  MockingTests.swift
+//  Swifty_Tests
+//
+//  Created by Siddharth Gupta on 13/12/17.
+//  Copyright © 2017 CocoaPods. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import Swifty
+
+class MockingTests: XCTestCase {
+    
+    class TestWebService: WebService {
+        
+        static var serverURL = "https://httpbin.org"
+        static var networkInterface: WebServiceNetworkInterface = Swifty()
+        
+        static func get(statusCode: Int) -> NetworkResource {
+            return server.get("/status/\(statusCode)")
+        }
+
+    }
+    
+    func testResponseMocking() {
+        
+        let expectation = self.expectation(description: "Should get mocked response from the file")
+        
+        TestWebService.get(statusCode: 200).mock(filename: "mockedResponse").loadJSON(successBlock: { (response) in
+            XCTAssertNotNil(response)
+            XCTAssert(response is [String: Any])
+            if let json = response as? [String: Any], let message = json["message"] as? String {
+                XCTAssertEqual(message, "This is the mocked response")
+                expectation.fulfill()
+            }
+        }) { (error) in
+            XCTFail()
+        }
+        
+        self.waitForExpectations(timeout: 4, handler: nil)
+    }
+}
+
+
+
+

--- a/Example/Tests/MockingTests.swift
+++ b/Example/Tests/MockingTests.swift
@@ -17,8 +17,8 @@ class MockingTests: XCTestCase {
         static var serverURL = "https://httpbin.org"
         static var networkInterface: WebServiceNetworkInterface = Swifty()
         
-        static func get(statusCode: Int) -> NetworkResource {
-            return server.get("/status/\(statusCode)")
+        static func getIP() -> NetworkResource {
+            return server.get("ip")
         }
 
     }
@@ -27,7 +27,7 @@ class MockingTests: XCTestCase {
         
         let expectation = self.expectation(description: "Should get mocked response from the file")
         
-        TestWebService.get(statusCode: 200).mock(filename: "mockedResponse").loadJSON(successBlock: { (response) in
+        TestWebService.getIP().mock(filename: "mockedResponse").loadJSON(successBlock: { (response) in
             XCTAssertNotNil(response)
             XCTAssert(response is [String: Any])
             if let json = response as? [String: Any], let message = json["message"] as? String {

--- a/Example/Tests/PerformanceTests.swift
+++ b/Example/Tests/PerformanceTests.swift
@@ -34,7 +34,7 @@ class PerformanceTests: XCTestCase {
     
     func testGET() {
         
-        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true) {
+        measureMetrics([XCTPerformanceMetric.wallClockTime], automaticallyStartMeasuring: true) {
             let expec = self.expectation(description: "GET")
             
             self.manager!.add(NetworkResource(request: self.GETRequest), successBlock: { (networkResponse) in
@@ -55,7 +55,7 @@ class PerformanceTests: XCTestCase {
 
     func testPOST() {
         
-        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true) {
+        measureMetrics([XCTPerformanceMetric.wallClockTime], automaticallyStartMeasuring: true) {
             let expec = self.expectation(description: "POST")
             
             self.manager!.add(NetworkResource(request: self.POSTRequest), successBlock: { (networkResponse) in
@@ -75,7 +75,7 @@ class PerformanceTests: XCTestCase {
     
     func testGET_URLSession() {
         
-        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true) {
+        measureMetrics([XCTPerformanceMetric.wallClockTime], automaticallyStartMeasuring: true) {
             let expec = self.expectation(description: "nGET")
             
             self.session?.dataTask(with: self.GETRequest, completionHandler: { (data, response, error) in
@@ -94,7 +94,7 @@ class PerformanceTests: XCTestCase {
     
     func testPOST_URLSession() {
         
-        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true) {
+        measureMetrics([XCTPerformanceMetric.wallClockTime], automaticallyStartMeasuring: true) {
             let expec = self.expectation(description: "nPOST")
             
             self.session?.dataTask(with: self.POSTRequest, completionHandler: { (data, response, error) in
@@ -113,7 +113,7 @@ class PerformanceTests: XCTestCase {
 
     func testGET_Alamofire() {
         
-        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true) {
+        measureMetrics([XCTPerformanceMetric.wallClockTime], automaticallyStartMeasuring: true) {
             let expec = self.expectation(description: "aGET")
             
             Alamofire.request(self.GETRequest).responseJSON { response in
@@ -133,7 +133,7 @@ class PerformanceTests: XCTestCase {
     
     func testPOST_Alamofire() {
         
-        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true) {
+        measureMetrics([XCTPerformanceMetric.wallClockTime], automaticallyStartMeasuring: true) {
             let expec = self.expectation(description: "aPOST")
             
             Alamofire.request(self.POSTRequest).responseJSON { response in

--- a/Example/Tests/mockedResponse.json
+++ b/Example/Tests/mockedResponse.json
@@ -1,0 +1,3 @@
+{
+    "message": "This is the mocked response"
+}

--- a/Sources/Core/SwiftyNetworkTask.swift
+++ b/Sources/Core/SwiftyNetworkTask.swift
@@ -55,11 +55,11 @@ class SwiftyNetworkTask: Task {
             return
         }
         
-        
+        /// Check if there is mocked data avaible for the resource. If yes, return the mocked response.
         guard self.resource.mockedData == nil else {
             #if DEBUG
             #else
-                print("[Swifty] 🚨🚨🚨🚨🚨🚨 WARNING: You're using response MOCKING in a build configuration other than Debug: Is this INTENTIONAL? 🚨🚨🚨🚨🚨🚨")
+                print("[Swifty] 🚨🚨🚨🚨🚨🚨 WARNING: You're using response MOCKING in a build configuration other than DEBUG: Is this Intentional? 🚨🚨🚨🚨🚨🚨")
             #endif
             self.finish(with: .success(NetworkResponse(response: nil, data: self.resource.mockedData, error: nil, parser: self.resource.parser)))
             return

--- a/Sources/Core/SwiftyNetworkTask.swift
+++ b/Sources/Core/SwiftyNetworkTask.swift
@@ -54,6 +54,14 @@ class SwiftyNetworkTask: Task {
             self.finish(with: .error(NetworkResponse(error: self.resource.creationError)))
             return
         }
+        
+        #if DEBUG
+            guard self.resource.mockedData == nil else {
+                self.finish(with: .success(NetworkResponse(response: nil, data: self.resource.mockedData, error: nil, parser: self.resource.parser)))
+                return
+            }
+        #endif
+     
         /// Intercepts the request with the request interceptors defined.
         self.interceptors.forEach { self.resource = $0.intercept(resource: self.resource) }
         /// Creates a Data Task

--- a/Sources/Core/SwiftyNetworkTask.swift
+++ b/Sources/Core/SwiftyNetworkTask.swift
@@ -55,12 +55,16 @@ class SwiftyNetworkTask: Task {
             return
         }
         
-        #if DEBUG
-            guard self.resource.mockedData == nil else {
-                self.finish(with: .success(NetworkResponse(response: nil, data: self.resource.mockedData, error: nil, parser: self.resource.parser)))
-                return
-            }
-        #endif
+        
+        guard self.resource.mockedData == nil else {
+            #if DEBUG
+            #else
+                print("[Swifty] 🚨🚨🚨🚨🚨🚨 WARNING: You're using response MOCKING in a build configuration other than Debug: Is this INTENTIONAL? 🚨🚨🚨🚨🚨🚨")
+            #endif
+            self.finish(with: .success(NetworkResponse(response: nil, data: self.resource.mockedData, error: nil, parser: self.resource.parser)))
+            return
+        }
+        
      
         /// Intercepts the request with the request interceptors defined.
         self.interceptors.forEach { self.resource = $0.intercept(resource: self.resource) }

--- a/Sources/WebService/NetworkResource+Modifiers.swift
+++ b/Sources/WebService/NetworkResource+Modifiers.swift
@@ -175,6 +175,15 @@ public extension NetworkResource {
         return self
     }
     
+    @objc @discardableResult func mock(filename: String) -> NetworkResource {
+        guard let path = Bundle.main.path(forResource: filename, ofType: "json"), let data = try? Data(contentsOf: URL(fileURLWithPath: path)), data.count > 0 else {
+            print("[Swifty] Unable to mock response from file: \(filename). Make sure the filename is correct, the file has an extension of .json, and is present in the main bundle of your app. Also make sure the file is not empty.")
+            return self
+        }
+        self.mockedData = data
+        return self
+    }
+    
     /// Constructs the query parameters from the given key and value
     ///
     /// - Parameters:

--- a/Sources/WebService/NetworkResource+Modifiers.swift
+++ b/Sources/WebService/NetworkResource+Modifiers.swift
@@ -125,6 +125,20 @@ public extension NetworkResource {
     
 // MARK: - Request Options Modifiers
     
+    /// Mocks the response of the resource with the contents of the given filename. Note that if a request is mocked, it'll never hit the network, and will NOT pass the Request Interceptors. It will, however, pass through the Response Intereptors.
+    ///
+    /// - Parameter withFile: The name (without extension) of the file containing the mocked response. The file must be present in the main bundle (`Bundle.main`)
+    /// - Parameter ofType: The extension of the file. Defaults to `.json` if not provided.
+    /// - Returns: NetworkResource
+    @objc @discardableResult func mock(withFile: String, ofType: String = "json") -> NetworkResource {
+        guard let path = Bundle.main.path(forResource: withFile, ofType: ofType), let data = try? Data(contentsOf: URL(fileURLWithPath: path)), data.count > 0 else {
+            print("[Swifty] Unable to mock response from file: \(withFile).\(ofType): Make sure the filename and extension are correct, and the file is present in the main bundle of your app. Also make sure the file is not empty.")
+            return self
+        }
+        self.mockedData = data
+        return self
+    }
+    
     /// Sets whether the request should wait for Constraints or not. `false` by default.
     ///
     /// If false, this request will not call any of the given Constraint's methods, and will directly go the the Request Interceptors.
@@ -172,15 +186,6 @@ public extension NetworkResource {
     /// - Returns: NetworkResource
     @objc @discardableResult func contentType(_ contentType: String) -> NetworkResource {
         self.request.setValue(contentType, forHTTPHeaderField: "Content-Type")
-        return self
-    }
-    
-    @objc @discardableResult func mock(filename: String) -> NetworkResource {
-        guard let path = Bundle.main.path(forResource: filename, ofType: "json"), let data = try? Data(contentsOf: URL(fileURLWithPath: path)), data.count > 0 else {
-            print("[Swifty] Unable to mock response from file: \(filename). Make sure the filename is correct, the file has an extension of .json, and is present in the main bundle of your app. Also make sure the file is not empty.")
-            return self
-        }
-        self.mockedData = data
         return self
     }
     

--- a/Sources/WebService/NetworkResource.swift
+++ b/Sources/WebService/NetworkResource.swift
@@ -39,6 +39,8 @@ public class NetworkResource: NSObject {
     /// Can have constraints.
     var canHaveConstraints = false
     
+    var mockedData: Data?
+    
     /// Error (if any) encountered while Webservice was creating this request.
     ///
     /// Set this error in your own extensions of `NetworkResource` or `NetworkResourceWithBody` Modifiers to inform callers of errors that fail the request, for example, JSON encoding failures.

--- a/Sources/WebService/NetworkResource.swift
+++ b/Sources/WebService/NetworkResource.swift
@@ -36,9 +36,10 @@ public class NetworkResource: NSObject {
     /// Tags allow you to categorize your requests, which helps you to recognize them in your interceptors and constraints to take selective action
     public var tags = Set<String>()
     
-    /// Can have constraints.
+    /// Can have constraints
     var canHaveConstraints = false
     
+    /// Mocked Data for the resource. Set using the `.mock()` modifier
     var mockedData: Data?
     
     /// Error (if any) encountered while Webservice was creating this request.

--- a/Sources/WebService/NetworkResourceWithBody.swift
+++ b/Sources/WebService/NetworkResourceWithBody.swift
@@ -214,6 +214,16 @@ public extension NetworkResourceWithBody {
     
     // MARK: - Request Options Modifiers
     
+    /// Mocks the response of the resource with the contents of the given filename. Note that if a request is mocked, it'll never hit the network, and will NOT pass the Request Interceptors. It will, however, pass through the Response Intereptors.
+    ///
+    /// - Parameter withFile: The name (without extension) of the file containing the mocked response. The file must be present in the main bundle (`Bundle.main`)
+    /// - Parameter ofType: The extension of the file. Defaults to `.json` if not provided.
+    /// - Returns: NetworkResourceWithBody
+    @objc @discardableResult override func mock(withFile: String, ofType: String = "json") -> NetworkResourceWithBody {
+        super.mock(withFile: withFile, ofType: ofType)
+        return self
+    }
+    
     /// Sets whether the request should wait for Constraints or not. `false` by default.
     ///
     /// If false, this request will not call any of the given Constraint's methods, and will directly go the the Request Interceptors.


### PR DESCRIPTION
- New `.mock(withFile: OfType)` modifier to mock responses of requests using files in the main bundle.
- Moved the Example Project to Swift 4.
- Added tests for response mocking.