### PR TITLE
Method to set POST request body with NSData

### DIFF
--- a/Sources/WebService/NetworkResourceWithBody.swift
+++ b/Sources/WebService/NetworkResourceWithBody.swift
@@ -157,6 +157,28 @@ public extension NetworkResourceWithBody {
         }
         return self
     }
+
+    /// Sets the HTTP Body with NSData
+    ///
+    /// Internally sets the Content-Type header of the resource to "application/json"
+    ///
+    /// - Parameters:
+    ///   - body: JSON serialised request body
+    /// - Returns: NetworkResourceWithBody
+    @objc @discardableResult func json(body: Data) -> NetworkResourceWithBody {
+
+        ///Checking for creation error
+        guard self.creationError == nil else {
+            return self
+        }
+        ///Sets the content type
+        self.contentType("application/json")
+
+        ///Sets the HTTP Body
+        self.request.httpBody = body
+
+        return self
+    }
     
     /// Sets the HTTP Body as JSON encoded from a type conforming to the `Encodable (Codable)` protocol
     ///

--- a/Swifty.podspec
+++ b/Swifty.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Swifty'
-  s.version          = '1.3.0'
+  s.version          = '1.3.1'
   s.summary          = 'Lightweight & Fast Network Abstraction Layer for iOS'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Existing post method accepts dictionary and internally does serialisation.

Added support to pass NSData which is directly set as POST body