### PR TITLE
Appending path only when it is not empty

### DIFF
--- a/Sources/WebService/BaseResource.swift
+++ b/Sources/WebService/BaseResource.swift
@@ -112,7 +112,9 @@ public extension BaseResource {
 fileprivate extension URL {
     
     mutating func appendPathComponentPreservingQuery(path: String, isDirectory: Bool) {
-        
+        guard !path.isEmpty else {
+            return
+        }
         if(path.contains("?")){
             let split = path.split(separator: "?", maxSplits: 1, omittingEmptySubsequences: true)
             if split.count > 1 {
@@ -125,9 +127,8 @@ fileprivate extension URL {
                 return
             }
         }
-        if !path.isEmpty {
-            self.appendPathComponent(path, isDirectory: isDirectory)
-        }
+
+        self.appendPathComponent(path, isDirectory: isDirectory)
         return
     }
     

--- a/Sources/WebService/BaseResource.swift
+++ b/Sources/WebService/BaseResource.swift
@@ -125,8 +125,9 @@ fileprivate extension URL {
                 return
             }
         }
-        
-        self.appendPathComponent(path, isDirectory: isDirectory)
+        if !path.isEmpty {
+            self.appendPathComponent(path, isDirectory: isDirectory)
+        }
         return
     }
     

--- a/Swifty.podspec
+++ b/Swifty.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Swifty'
-  s.version          = '1.3.3'
+  s.version          = '1.3.4'
   s.summary          = 'Lightweight & Fast Network Abstraction Layer for iOS'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Issue - 

var url = URL(string: "https://api.example.com")!
url = url.appendingPathComponent("")
**https://api.example.com/**

url = URL(string: "https://api.example.com?aws=123")!
url = url.appendingPathComponent("")
**https://api.example.com/?aws=123**

When a query param is present in the url and we are appending an empty string, 
it adds a slash(/) before the questionmark(?) and modifies the whole url.

Solve - 
Appending the path only when it is not empty.